### PR TITLE
Add Spanish Code Spell Checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "novom-extension-pack",
     "displayName": "novom-extension-pack",
     "description": "",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "engines": {
         "vscode": "^1.32.0"
     },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "ue.alphabetical-sorter",
         "xabikos.JavaScriptSnippets",
         "streetsidesoftware.code-spell-checker",
-        "streetsidesoftware.code-spell-checker-french"
+        "streetsidesoftware.code-spell-checker-french",
+        "streetsidesoftware.code-spell-checker-spanish"
     ]
 }


### PR DESCRIPTION
Ajoute l'espagnol dans les extensions pour Code Spell Checker puisque certains projets vont maintenant être offerts en 3 langues.